### PR TITLE
fix: have `readme-section` match the example yaml

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -15,5 +15,5 @@ jobs:
       - uses: JasonEtco/rss-to-readme@v1
         with:
           feed-url: https://jasonet.co/rss.xml
-          readme-section: feed
+          readme-section: example
 

--- a/README.md
+++ b/README.md
@@ -52,12 +52,12 @@ The maximum number of items to show from the RSS feed. Defaults to `5`!
 
 ### Example RSS feed:
 
-<!--START_SECTION:feed-->
+<!--START_SECTION:example-->
 * [Probot App or GitHub Action? (Updated)](https://jasonet.co/posts/probot-app-or-github-action-v2/)
 * [Build your own Probot](https://jasonet.co/posts/build-your-own-probot/)
 * [New features of GitHub Actions v2](https://jasonet.co/posts/new-features-of-github-actions/)
 * [Run your GitHub Actions workflow on a schedule](https://jasonet.co/posts/scheduled-actions/)
 * [Just enough Docker](https://jasonet.co/posts/just-enough-docker/)
-<!--END_SECTION:feed-->
+<!--END_SECTION:example-->
 
 > This started as a little proof-of-concept for @brianlovin!

--- a/README.md
+++ b/README.md
@@ -34,14 +34,14 @@ The URL to an RSS feed. It's assumed that the RSS feed follow the standard forma
 
 #### `readme-section`:
 
-The name of the section of your README to update. This uses [`JasonEtco/readme-box`](https://github.com/JasonEtco/readme-box) to replace a section of the README and update the file. Your README should contain HTML comments like this, where `example` is the the value of `readme-section`:
+The name of the section of your README to update. This uses [`JasonEtco/readme-box`](https://github.com/JasonEtco/readme-box) to replace a section of the README and update the file. Your README should contain HTML comments like this, where `feed` is the the value of `readme-section`:
 
 ```html
 ### Example RSS feed:
 
-<!--START_SECTION:example-->
+<!--START_SECTION:feed-->
 ...
-<!--END_SECTION:example-->
+<!--END_SECTION:feed-->
 ```
 
 You can inspect this repo's README to see it in use!


### PR DESCRIPTION
tiny change that makes it slightly easier to copy/paste