### PR TITLE
Add support for `template` input

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,15 @@ The maximum number of items to show from the RSS feed. Defaults to `5`!
 
 #### `template` (default: `"* [{{ title }}]({{ link }}))"`)
 
-The template to use when rendering each item in the feed. These will be joined by a newline (`\n`).
+You can provide a [Mustache](https://github.com/janl/mustache.js) template to use when rendering each item in the feed. These will be joined by a newline (`\n`). For example:
+
+```yaml
+- uses: JasonEtco/rss-to-readme@v1
+  with:
+    feed-url: https://jasonet.co/rss.xml
+    template: "> {{ excerpt }}\n\n[Read more!]({{ url }})"
+```
+
 
 ### Example RSS feed:
 

--- a/README.md
+++ b/README.md
@@ -50,6 +50,10 @@ You can inspect this repo's README to see it in use!
 
 The maximum number of items to show from the RSS feed. Defaults to `5`!
 
+#### `template` (default: `"* [{{ title }}]({{ link }}))"`)
+
+The template to use when rendering each item in the feed. These will be joined by a newline (`\n`).
+
 ### Example RSS feed:
 
 <!--START_SECTION:example-->

--- a/action.yml
+++ b/action.yml
@@ -10,6 +10,9 @@ inputs:
   max:
     default: 5
     description: The maximum number of RSS feed items to show.
+  template:
+    default: '* [{{ title }}]({{ link }})'
+    description: The template to use for each item in the RSS feed. These are joined by a new line.
   github_token:
     default: ${{ github.token }}
 runs:

--- a/package-lock.json
+++ b/package-lock.json
@@ -148,6 +148,12 @@
       "resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.0.tgz",
       "integrity": "sha1-aaI6OtKcrwCX8G7aWbNh7i8GOfY="
     },
+    "@types/mustache": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@types/mustache/-/mustache-4.0.1.tgz",
+      "integrity": "sha512-wH6Tu9mbiOt0n5EvdoWy0VGQaJMHfLIxY/6wS0xLC7CV1taM6gESEzcYy0ZlWvxxiiljYvfDIvz4hHbUUDRlhw==",
+      "dev": true
+    },
     "@types/node": {
       "version": "14.0.5",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-14.0.5.tgz",
@@ -371,6 +377,11 @@
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
       "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+    },
+    "mustache": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/mustache/-/mustache-4.0.1.tgz",
+      "integrity": "sha512-yL5VE97+OXn4+Er3THSmTdCFCtx5hHWzrolvH+JObZnUYwuaG7XV+Ch4fR2cIrcYI0tFHxS7iyFYl14bW8y2sA=="
     },
     "nice-try": {
       "version": "1.0.5",

--- a/package.json
+++ b/package.json
@@ -9,10 +9,12 @@
   "license": "MIT",
   "dependencies": {
     "actions-toolkit": "^5.0.0",
+    "mustache": "^4.0.1",
     "readme-box": "^0.1.2",
     "rss-parser": "^3.8.0"
   },
   "devDependencies": {
+    "@types/mustache": "^4.0.1",
     "@zeit/ncc": "^0.22.3"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 import { Toolkit } from 'actions-toolkit'
 import { ReadmeBox } from 'readme-box'
 import Parser from 'rss-parser'
+import mustache from 'mustache'
 
 const parser = new Parser()
 
@@ -8,6 +9,7 @@ interface Inputs {
   'feed-url': string
   'readme-section': string
   max: string
+  template: string
   [key: string]: string
 }
 
@@ -22,7 +24,7 @@ Toolkit.run<Inputs>(async tools => {
   // Create our new list
   const newString = feed.items
     .slice(0, parseInt(tools.inputs.max, 10)) 
-    .map(item => `* [${item.title}](${item.link})`).join('\n')
+    .map(item => mustache.render(tools.inputs.template, item)).join('\n')
 
   // Update the section of our README
   await ReadmeBox.updateSection(newString, {


### PR DESCRIPTION
This adds an input `template`, which takes a [mustache template](https://github.com/janl/mustache.js) string. The default is unchanged, so this is an optional input.

Usage:

```yaml
- uses: JasonEtco/rss-to-readme@v1
  with:
    feed-url: https://jasonet.co/rss.xml
    template: "> {{ excerpt }}\n\n[Read more!]({{ url }})"
```

cc @pmarsceill 👋 