### PR TITLE
Add a 'branch' configuration option

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,9 @@ You can provide a [Mustache](https://github.com/janl/mustache.js) template to us
     template: "> {{ excerpt }}\n\n[Read more!]({{ url }})"
 ```
 
+#### `branch` (default: master)
+
+You can provide the target branch to update instead of the default.
 
 ### Example RSS feed:
 

--- a/action.yml
+++ b/action.yml
@@ -1,7 +1,7 @@
 name: RSS to README
 description: Replaces a section of the repo's README with the contents of an RSS feed
 inputs:
-  feed-url: 
+  feed-url:
     required: true
     description: A URL to an RSS feed.
   readme-section:
@@ -15,6 +15,9 @@ inputs:
     description: The template to use for each item in the RSS feed. These are joined by a new line.
   github_token:
     default: ${{ github.token }}
+  branch:
+    default: master
+    description: The target branch to update.
 runs:
   using: node12
   main: dist/index.js

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ interface Inputs {
   'readme-section': string
   max: string
   template: string
+  branch: string
   [key: string]: string
 }
 
@@ -30,6 +31,7 @@ Toolkit.run<Inputs>(async tools => {
   await ReadmeBox.updateSection(newString, {
     ...tools.context.repo,
     token: tools.token,
-    section: tools.inputs['readme-section']
+    section: tools.inputs['readme-section'],
+    branch: this.inputs.branch
   })
 })


### PR DESCRIPTION
Adding an optional `branch` setting allows updating the README on repositories where the main branch is something other than `master`.