### PR TITLE
Use nunjucks instead of mustache, with a date filter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -181,16 +181,16 @@
       "resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.0.tgz",
       "integrity": "sha1-aaI6OtKcrwCX8G7aWbNh7i8GOfY="
     },
-    "@types/mustache": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/@types/mustache/-/mustache-4.1.1.tgz",
-      "integrity": "sha512-Sm0NWeLhS2QL7NNGsXvO+Fgp7e3JLHCO6RS3RCnfjAnkw6Y1bsji/AGfISdQZDIR/AeOyzkrxRk9jBkl55zdJw==",
-      "dev": true
-    },
     "@types/node": {
       "version": "14.0.5",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-14.0.5.tgz",
       "integrity": "sha512-90hiq6/VqtQgX8Sp0EzeIsv3r+ellbGj4URKj5j30tLlZvRUpnAe9YbYnjl3pJM93GyXU0tghHhvXHq+5rnCKA=="
+    },
+    "@types/nunjucks": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/@types/nunjucks/-/nunjucks-3.1.5.tgz",
+      "integrity": "sha512-0zEdmQNNvQ+xyV9kqQvAV93UVroTwhE78toVUDT0GBnGcW2jQBZnB4al9qq2LqI5qHOqROy/DvvAY/UwrbvV1A==",
+      "dev": true
     },
     "@types/signale": {
       "version": "1.4.1",
@@ -200,11 +200,16 @@
         "@types/node": "*"
       }
     },
-    "@zeit/ncc": {
-      "version": "0.22.3",
-      "resolved": "https://registry.npmjs.org/@zeit/ncc/-/ncc-0.22.3.tgz",
-      "integrity": "sha512-jnCLpLXWuw/PAiJiVbLjA8WBC0IJQbFeUwF4I9M+23MvIxTxk5pD4Q8byQBSPmHQjz5aBoA7AKAElQxMpjrCLQ==",
+    "@vercel/ncc": {
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@vercel/ncc/-/ncc-0.30.0.tgz",
+      "integrity": "sha512-16ePj2GkwjomvE0HLL5ny+d+sudOwvZNYW8vjpMh3cyWdFxoMI8KSQiolVxeHBULbU1C5mVxLK5nL9NtnnpIew==",
       "dev": true
+    },
+    "a-sync-waterfall": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/a-sync-waterfall/-/a-sync-waterfall-1.0.1.tgz",
+      "integrity": "sha512-RYTOHHdWipFUliRFMCS4X2Yn2X8M87V/OpSqWzKKOGhzqyUxzyVmhHDH9sAvG+ZuQf/TAOFsLCpMw09I1ufUnA=="
     },
     "actions-toolkit": {
       "version": "6.0.1",
@@ -235,6 +240,11 @@
         "color-convert": "^1.9.0"
       }
     },
+    "asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
+    },
     "before-after-hook": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.1.0.tgz",
@@ -262,6 +272,11 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+    },
+    "commander": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
+      "integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg=="
     },
     "cross-spawn": {
       "version": "6.0.5",
@@ -411,10 +426,10 @@
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
       "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
     },
-    "mustache": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/mustache/-/mustache-4.1.0.tgz",
-      "integrity": "sha512-0FsgP/WVq4mKyjolIyX+Z9Bd+3WS8GOwoUTyKXT5cTYMGeauNTi2HPCwERqseC1IHAy0Z7MDZnJBfjabd4O8GQ=="
+    "moment": {
+      "version": "2.29.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
+      "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ=="
     },
     "nice-try": {
       "version": "1.0.5",
@@ -432,6 +447,24 @@
       "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
       "requires": {
         "path-key": "^2.0.0"
+      }
+    },
+    "nunjucks": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/nunjucks/-/nunjucks-3.2.3.tgz",
+      "integrity": "sha512-psb6xjLj47+fE76JdZwskvwG4MYsQKXUtMsPh6U0YMvmyjRtKRFcxnlXGWglNybtNTNVmGdp94K62/+NjF5FDQ==",
+      "requires": {
+        "a-sync-waterfall": "^1.0.0",
+        "asap": "^2.0.3",
+        "commander": "^5.1.0"
+      }
+    },
+    "nunjucks-date-filter": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/nunjucks-date-filter/-/nunjucks-date-filter-0.1.1.tgz",
+      "integrity": "sha1-qTbUTSzJiY2Vxqt7KrpwhPpgq6Y=",
+      "requires": {
+        "moment": "^2.9.0"
       }
     },
     "once": {

--- a/package.json
+++ b/package.json
@@ -9,13 +9,14 @@
   "license": "MIT",
   "dependencies": {
     "actions-toolkit": "^6.0.1",
-    "mustache": "^4.1.0",
+    "nunjucks": "^3.2.3",
+    "nunjucks-date-filter": "^0.1.1",
     "readme-box": "^1.0.0",
     "rss-parser": "^3.12.0"
   },
   "devDependencies": {
-    "@types/mustache": "^4.1.1",
-    "@zeit/ncc": "^0.22.3",
+    "@types/nunjucks": "^3.1.5",
+    "@vercel/ncc": "^0.30.0",
     "typescript": "^4.2.2"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,13 @@
 import { Toolkit } from 'actions-toolkit'
 import { ReadmeBox } from 'readme-box'
 import Parser from 'rss-parser'
-import mustache from 'mustache'
+import nunjucks from 'nunjucks'
+// @ts-ignore
+import dateFilter from 'nunjucks-date-filter'
 
 const parser = new Parser()
+const env = nunjucks.configure({ autoescape: false })
+env.addFilter('date', dateFilter)
 
 interface Inputs {
   'feed-url': string
@@ -43,7 +47,7 @@ Toolkit.run<Inputs>(async tools => {
   // Create our new list
   const newString = feed.items
     .slice(0, parseInt(tools.inputs.max, 10)) 
-    .map(item => mustache.render(tools.inputs.template, item)).join('\n')
+    .map(item => env.renderString(tools.inputs.template, item)).join('\n')
 
   // Prepare some options
   const emptyCommits = tools.inputs['empty-commits'] !== 'false'


### PR DESCRIPTION
Switches to Nunjucks instead of Mustache for the templates - this shouldn't be a breaking change for most uses, but I'm marking it as such to be safe. Also adds the `nunjucks-date-filter` package for easy date formatting.