### PR TITLE
fix: improve error messages for timeout and HTTP errors

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -38,7 +38,22 @@ async function getReadme(tools: Toolkit, branch: string, path: string) {
 
 Toolkit.run<Inputs>(async tools => {
   // Fetch feed
-  const feed = await parser.parseURL(tools.inputs['feed-url'])
+  const feedUrl = tools.inputs['feed-url']
+  let feed
+  try {
+    feed = await parser.parseURL(feedUrl)
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : String(error)
+    const timeout = (parser as any).options.timeout
+    if (message.includes('timed out')) {
+      throw new Error(`Request to ${feedUrl} timed out after ${timeout}ms`)
+    }
+    const statusMatch = message.match(/Status code (\d+)/)
+    if (statusMatch) {
+      throw new Error(`Error fetching ${feedUrl}: received status code ${statusMatch[1]}`)
+    }
+    throw new Error(`Failed to fetch RSS feed from ${feedUrl}: ${message}`)
+  }
 
   if (!feed.items) {
     throw new Error('feed.items was not found!')


### PR DESCRIPTION
## Changes
- Wrapped `parser.parseURL()` in a try/catch to provide meaningful error messages
- Timeout errors now include the feed URL and timeout duration (fixes #35)
- HTTP errors (like 403) now include the feed URL and status code (fixes #34)
- Other errors now include the feed URL and original error message

## Error Message Examples

Before: Request timed out after 60000ms
After: Request to https://example.com/feed.xml timed out after 60000ms

Before: Status code 403
After: Error fetching https://example.com/feed.xml: received status code 403

## Related Issues
- Fixes #35: timeout errors have no debugging information
- Fixes #34: 403 errors with no context